### PR TITLE
Fix NULL value handling

### DIFF
--- a/source/R/get_bootstrap_ci.R
+++ b/source/R/get_bootstrap_ci.R
@@ -24,7 +24,7 @@ get_bootstrap_ci <- function(bootstrap_list, ...) {
   # Exit if there are no values
   if (length(conf_ints) == 0) {
     return(conf_ints)
-    }
+  }
 
   # Get interval names
   indices_to_remove <- match(c("R", "t0", "call"), names(conf_ints[[1]]))

--- a/source/R/get_bootstrap_ci.R
+++ b/source/R/get_bootstrap_ci.R
@@ -19,13 +19,13 @@ get_bootstrap_ci <- function(bootstrap_list, ...) {
   conf_ints <- lapply(bootstrap_list, boot::boot.ci, ...)
 
   # Remove null values
-  conf_ints[sapply(conf_ints, is_null)] <- NULL
+  conf_ints[sapply(conf_ints, is.null)] <- NULL
 
   # Exit if there are no values
   if (length(conf_ints) == 0) {
     return(conf_ints)
     }
-  
+
   # Get interval names
   indices_to_remove <- match(c("R", "t0", "call"), names(conf_ints[[1]]))
   interval_types <- names(conf_ints[[1]])[-indices_to_remove]

--- a/source/R/get_bootstrap_ci.R
+++ b/source/R/get_bootstrap_ci.R
@@ -18,6 +18,14 @@ get_bootstrap_ci <- function(bootstrap_list, ...) {
   # Calculate nonparametric confidence intervals
   conf_ints <- lapply(bootstrap_list, boot::boot.ci, ...)
 
+  # Remove null values
+  conf_ints[sapply(conf_ints, is_null)] <- NULL
+
+  # Exit if there are no values
+  if (length(conf_ints) == 0) {
+    return(conf_ints)
+    }
+  
   # Get interval names
   indices_to_remove <- match(c("R", "t0", "call"), names(conf_ints[[1]]))
   interval_types <- names(conf_ints[[1]])[-indices_to_remove]


### PR DESCRIPTION
Fix the case where the first confidence interval is NULL, but at least one is not, which results in an error... this occurs because some lines in the function rely on this one not being NULL. This code removes the NULL list item(s) causing the error. It then exits the function if all list items were NULL.